### PR TITLE
Fix nixpacks.toml syntax error for Railway deployment

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,4 @@
-[providers]
-go = "1.21"
+providers = ["go"]
 
 [variables]
 PORT = "8080"


### PR DESCRIPTION
## Problem
Railway deployment failing with Nixpacks build error:
```
Error: Failed to parse Nixpacks config file `nixpacks.toml`
Caused by: invalid type: map, expected a sequence for key `providers`
```

## Root Cause
The `providers` section in nixpacks.toml was using map syntax instead of array syntax.

## Fix
- ❌ **Before**: `[providers] go = "1.21"` (map syntax)
- ✅ **After**: `providers = ["go"]` (array syntax)

## Result
- ✅ Nixpacks config now parses correctly
- ✅ Railway can properly detect and use Go buildpack
- ✅ Deployment should proceed without config errors

This is a critical fix to unblock Railway deployment after the previous Docker → Go buildpack migration.

🤖 Generated with [Claude Code](https://claude.ai/code)