### PR TITLE
Parallelize temperature image fetch and add warning banner

### DIFF
--- a/internal/handlers/temperatures.go
+++ b/internal/handlers/temperatures.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"wichitaradar/internal/middleware"
@@ -34,23 +35,43 @@ func NewSWXCOFiles() *SWXCOFiles {
 }
 
 func (s *SWXCOFiles) getImagePaths() map[string]string {
-	for _, imagetype := range s.images {
-		imageFound := false
-		for hoursAgo := 0; hoursAgo < s.maxHoursAgo; hoursAgo++ {
-			timeToCheck := s.runtime.Add(-time.Duration(hoursAgo) * time.Hour)
-			imageUrl := fmt.Sprintf("%s/%s/%s/%s00z.jpg",
-				s.prefix,
-				imagetype,
-				timeToCheck.Format("20060102"),
-				timeToCheck.Format("15"))
+	type hit struct {
+		imagetype string
+		hoursAgo  int
+		url       string
+	}
+	hits := make(chan hit, len(s.images)*s.maxHoursAgo)
+	var wg sync.WaitGroup
 
-			if checkRemoteFile(imageUrl) {
-				s.imagePaths[imagetype] = imageUrl
-				imageFound = true
-				break
-			}
+	for _, imagetype := range s.images {
+		for hoursAgo := 0; hoursAgo < s.maxHoursAgo; hoursAgo++ {
+			wg.Add(1)
+			go func(imagetype string, hoursAgo int) {
+				defer wg.Done()
+				timeToCheck := s.runtime.Add(-time.Duration(hoursAgo) * time.Hour)
+				imageUrl := fmt.Sprintf("%s/%s/%s/%s00z.jpg",
+					s.prefix,
+					imagetype,
+					timeToCheck.Format("20060102"),
+					timeToCheck.Format("15"))
+				if checkRemoteFile(imageUrl) {
+					hits <- hit{imagetype, hoursAgo, imageUrl}
+				}
+			}(imagetype, hoursAgo)
 		}
-		if !imageFound {
+	}
+	wg.Wait()
+	close(hits)
+
+	best := make(map[string]int)
+	for h := range hits {
+		if existing, ok := best[h.imagetype]; !ok || h.hoursAgo < existing {
+			best[h.imagetype] = h.hoursAgo
+			s.imagePaths[h.imagetype] = h.url
+		}
+	}
+	for _, imagetype := range s.images {
+		if _, ok := s.imagePaths[imagetype]; !ok {
 			s.imagePaths[imagetype] = ""
 		}
 	}

--- a/static/css/wx.css
+++ b/static/css/wx.css
@@ -7,74 +7,74 @@
 
 html,
 body {
-    background-color: #252525;
+  background-color: #252525;
 }
 
 a {
-    color: #FFC000;
-    border: 0;
-    outline: 0;
+  color: #ffc000;
+  border: 0;
+  outline: 0;
 }
 
 img {
-    border: 0;
+  border: 0;
 }
 
 #menu {
-    background-color: #05028F;
+  background-color: #05028f;
 }
 
 #menu .pure-menu-item.selected {
-    background-color: #0A8EFC;
+  background-color: #0a8efc;
 }
 
 #menu .pure-menu-item.selected a {
-    color: #FFF;
+  color: #fff;
 }
 
 #menu .pure-menu li a:hover,
 #menu .pure-menu li a:focus {
-    background-color: #006AC2;
-    color: #FFF;
+  background-color: #006ac2;
+  color: #fff;
 }
 
 #menu .pure-menu-link {
-    /* text color of menu items that are not selected or hovered */
-    color: #7DC2FB;
+  /* text color of menu items that are not selected or hovered */
+  color: #7dc2fb;
 }
 
 #menu .new-menu-link {
-    position: absolute;
-    z-index: 1;
-    padding: 0 3px;
+  position: absolute;
+  z-index: 1;
+  padding: 0 3px;
 }
 
 #menu .new-menu-link img#new {
-    height: 20px;
+  height: 20px;
 }
 
 #menu .menu-footer {
-    font-size: 0.8em !important;
-    padding-left: 3px;
-    position: absolute;
-    bottom: 3px;
+  font-size: 0.8em !important;
+  padding-left: 3px;
+  position: absolute;
+  bottom: 3px;
 }
 
 .pure-u {
-    text-align: center !important;
+  text-align: center !important;
 }
 
 .header {
-    border-bottom: 1px solid #014884;
+  border-bottom: 1px solid #014884;
 }
 
 .header h1,
 .header h2 {
-    color: #45A6F7;
+  color: #45a6f7;
 }
 
 img.whitebg {
-    background-color: #FFFFFF;
+  background-color: #ffffff;
 }
 
 /*
@@ -88,61 +88,69 @@ button,
 input,
 select,
 textarea,
-.pure-g [class *="pure-u"] {
-    font-family: 'Open Sans', sans-serif;
-    color: #8F8F8F;
-    /* Set your content font stack here: */
-    /*font-family: Georgia, Times, "Times New Roman", serif;*/
+.pure-g [class*="pure-u"] {
+  font-family: "Open Sans", sans-serif;
+  color: #8f8f8f;
+  /* Set your content font stack here: */
+  /*font-family: Georgia, Times, "Times New Roman", serif;*/
 }
-
-
-
-
 
 /****
 	other misc css
 ****/
 
 .textbox {
-    width: 90%;
-    text-align: center;
-    background-color: #014884;
-    color: #FFF !important;
-    font-size: 0.8em;
-    border-top: 1px solid #45A6F7;
-    border-bottom: 1px solid #45A6F7;
-    padding: 0.5em 1em;
-    margin: 1em auto;
+  width: 90%;
+  text-align: center;
+  background-color: #014884;
+  color: #fff !important;
+  font-size: 0.8em;
+  border-top: 1px solid #45a6f7;
+  border-bottom: 1px solid #45a6f7;
+  padding: 0.5em 1em;
+  margin: 1em auto;
+}
+
+.textbox-warn {
+  width: 90%;
+  text-align: center;
+  background-color: #9a2820;
+  color: #fff !important;
+  font-size: 0.8em;
+  border-top: 1px solid #e74c3c;
+  border-bottom: 1px solid #e74c3c;
+  padding: 0.5em 1em;
+  margin: 1em auto;
 }
 
 .accuweather {
-    background-color: #FFF;
-    display: inline-block;
-    padding: 5px 5px 0 5px;
-    margin-bottom: 5px;
+  background-color: #fff;
+  display: inline-block;
+  padding: 5px 5px 0 5px;
+  margin-bottom: 5px;
 }
 
 #noaa_watches {
-    background-color: #FFF;
-    text-align: center;
-    display: table-cell;
+  background-color: #fff;
+  text-align: center;
+  display: table-cell;
 }
 
 #weathergov_legend {
-    background-color: #4C484A;
-    color: #FFF;
-    text-align: left;
-    font-size: 0.6em;
-    margin: 0 auto;
-    border-spacing: 2px;
-    border-collapse: separate;
+  background-color: #4c484a;
+  color: #fff;
+  text-align: left;
+  font-size: 0.6em;
+  margin: 0 auto;
+  border-spacing: 2px;
+  border-collapse: separate;
 }
 
 #weathergov_legend td {
-    padding: 1px 4px;
+  padding: 1px 4px;
 }
 
 .legend_cell {
-    border: 2px solid black;
-    width: 15px;
+  border: 2px solid black;
+  width: 15px;
 }

--- a/templates/temperatures.page.html
+++ b/templates/temperatures.page.html
@@ -1,53 +1,59 @@
-{{define "temperatures"}}
-{{template "base" .}}
-{{end}}
+{{define "temperatures"}} {{template "base" .}} {{end}} {{define "content"}}
+<div class="pure-g">
+  <div class="pure-u textbox-warn">
+    Apologies; we are having some trouble with some of our upstream temperature maps.
+  </div>
+  <div class="pure-u pure-u-md-1 pure-u-lg-1-2 pure-u-xl-1-3">
+    <!-- ****** KSNW ***** -->
+    <a href="https://www.ksn.com/weather/images/kansas-temps/">
+      <img
+        class="pure-img-responsive"
+        src="https://media.psg.nexstardigital.net/ksnw/weather/images/ksnow_full.jpg"
+        border="0"
+      />
+    </a>
 
-{{define "content"}}
-    <div class="pure-g">
-        <div class="pure-u pure-u-md-1 pure-u-lg-1-2 pure-u-xl-1-3">
-            <!-- ****** KSNW ***** -->
-            <a href="https://www.ksn.com/weather/images/kansas-temps/">
-                <img class="pure-img-responsive" src="https://media.psg.nexstardigital.net/ksnw/weather/images/ksnow_full.jpg" border="0" />
-            </a>
+    {{if .SWXCOFiles.ddc}}
+    <!-- ****** wunderground dodge city ****** -->
+    <a href="https://www.wunderground.com/maps/temperature/us-current/ddc">
+      <img class="pure-img-responsive" src="{{.SWXCOFiles.ddc}}" border="0" />
+    </a>
+    {{end}}
+  </div>
 
-            {{if .SWXCOFiles.ddc}}
-            <!-- ****** wunderground dodge city ****** -->
-        	<a href="https://www.wunderground.com/maps/temperature/us-current/ddc">
-                <img class="pure-img-responsive" src="{{.SWXCOFiles.ddc}}" border="0" />
-            </a>
-            {{end}}
-        </div>
+  <div class="pure-u pure-u-md-1 pure-u-lg-1-2 pure-u-xl-1-3">
+    <!-- ****** Weather.com **** -->
+    <a href="https://weather.com/maps/ustemperaturemap">
+      <img class="pure-img-responsive" src="https://s.w-x.co/staticmaps/acttemp_1280x720.jpg" border="0" />
+    </a>
 
-        <div class="pure-u pure-u-md-1 pure-u-lg-1-2 pure-u-xl-1-3">
-            <!-- ****** Weather.com **** -->
-            <a href="https://weather.com/maps/ustemperaturemap">
-                <img class="pure-img-responsive" src="https://s.w-x.co/staticmaps/acttemp_1280x720.jpg" border="0" />
-            </a>
+    {{if .SWXCOFiles.usa}}
+    <!-- ****** wunderground ****** -->
+    <a href="https://www.wunderground.com/maps/temperature/us-current/usa">
+      <img class="pure-img-responsive" src="{{.SWXCOFiles.usa}}" border="0" />
+    </a>
+    {{end}}
+  </div>
 
-            {{if .SWXCOFiles.usa}}
-            <!-- ****** wunderground ****** -->
-            <a href="https://www.wunderground.com/maps/temperature/us-current/usa">
-                <img class="pure-img-responsive" src="{{.SWXCOFiles.usa}}" border="0" />
-            </a>
-            {{end}}
-        </div>
+  <div class="pure-u pure-u-md-1 pure-u-lg-1-2 pure-u-xl-1-3">
+    <!-- ****** Weather.gov ***** -->
+    <a href="https://graphical.weather.gov/sectors/conus.php#tabs">
+      <img class="pure-img-responsive" src="https://graphical.weather.gov/images/conus/MaxT1_conus.png" border="0" />
+    </a>
 
-        <div class="pure-u pure-u-md-1 pure-u-lg-1-2 pure-u-xl-1-3">
-            <!-- ****** Weather.gov ***** -->
-            <a href="https://graphical.weather.gov/sectors/conus.php#tabs">
-                <img class="pure-img-responsive" src="https://graphical.weather.gov/images/conus/MaxT1_conus.png" border="0" />
-            </a>
+    <!-- ****** Weather.gov ***** -->
+    <a href="https://graphical.weather.gov/sectors/centplains.php#tabs">
+      <img
+        class="pure-img-responsive"
+        src="https://graphical.weather.gov/images/centplains/MaxT1_centplains.png"
+        border="0"
+      />
+    </a>
 
-            <!-- ****** Weather.gov ***** -->
-            <a href="https://graphical.weather.gov/sectors/centplains.php#tabs">
-                <img class="pure-img-responsive" src="https://graphical.weather.gov/images/centplains/MaxT1_centplains.png" border="0" />
-            </a>
-
-            <!-- ****** Weather.gov ***** -->
-            <a href="https://graphical.weather.gov/sectors/kansas.php#tabs">
-                <img class="pure-img-responsive" src="https://graphical.weather.gov/images/kansas/MaxT1_kansas.png" border="0" />
-            </a>
-        </div>
-
-    </div>
+    <!-- ****** Weather.gov ***** -->
+    <a href="https://graphical.weather.gov/sectors/kansas.php#tabs">
+      <img class="pure-img-responsive" src="https://graphical.weather.gov/images/kansas/MaxT1_kansas.png" border="0" />
+    </a>
+  </div>
+</div>
 {{end}}


### PR DESCRIPTION
## Summary
- Parallelize the 24 upstream HEAD checks in `HandleTemperatures` so a slow/unresponsive `s.w-x.co` host times out in ~5s instead of ~120s.
- Add a `.textbox-warn` red variant of `.textbox` and use it on `/temperatures` to flag users that upstream maps are degraded.

## Test plan
- [x] `make test-race` passes locally
- [x] Visit `/temperatures` locally and confirm the page renders in a few seconds even while `s.w-x.co` is unreachable
- [x] Verify the red warning banner renders with the new styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)