### PR TITLE
Fall back to last-good URL on WU probe network errors + cache results

### DIFF
--- a/internal/handlers/temperatures.go
+++ b/internal/handlers/temperatures.go
@@ -17,6 +17,27 @@ var imageCheckClient = &http.Client{
 	Timeout: 5 * time.Second,
 }
 
+const (
+	// wuResultTTL is how long we serve a previously-computed probe result
+	// before re-probing upstream. Keeps the 24-HEAD fan-out off the hot path.
+	wuResultTTL = 10 * time.Minute
+	// wuLastGoodMaxAge bounds how stale a last-known-good URL can be before
+	// we stop using it as a network-error fallback.
+	wuLastGoodMaxAge = 3 * time.Hour
+)
+
+type wuCacheEntry struct {
+	url string
+	at  time.Time
+}
+
+var (
+	wuMu           sync.Mutex
+	wuResult       map[string]string
+	wuResultAt     time.Time
+	wuLastGoodURLs = map[string]wuCacheEntry{}
+)
+
 type SWXCOFiles struct {
 	runtime     time.Time
 	prefix      string
@@ -35,11 +56,25 @@ func NewSWXCOFiles() *SWXCOFiles {
 	}
 }
 
+type probeResult int
+
+const (
+	probeMissing probeResult = iota // clean HTTP miss (e.g. 404)
+	probeFound                      // HTTP 200
+	probeNetErr                     // transport error (DNS, timeout, TCP reset)
+)
+
+// getImagePaths returns the freshest available image URL per region. When a
+// region has no HTTP hit but at least one probe failed with a transport error
+// (DNS, timeout, etc.), it falls back to the last known-good URL, or failing
+// that, the current-hour URL — so a server-side resolver hiccup doesn't blank
+// a slot whose image the user's browser could have loaded fine.
 func (s *SWXCOFiles) getImagePaths() map[string]string {
 	type hit struct {
 		imagetype string
 		hoursAgo  int
 		url       string
+		result    probeResult
 	}
 	hits := make(chan hit, len(s.images)*s.maxHoursAgo)
 	var wg sync.WaitGroup
@@ -50,14 +85,8 @@ func (s *SWXCOFiles) getImagePaths() map[string]string {
 			go func(imagetype string, hoursAgo int) {
 				defer wg.Done()
 				timeToCheck := s.runtime.Add(-time.Duration(hoursAgo) * time.Hour)
-				imageUrl := fmt.Sprintf("%s/%s/%s/%s00z.jpg",
-					s.prefix,
-					imagetype,
-					timeToCheck.Format("20060102"),
-					timeToCheck.Format("15"))
-				if checkRemoteFile(imageUrl) {
-					hits <- hit{imagetype, hoursAgo, imageUrl}
-				}
+				imageUrl := s.urlFor(imagetype, timeToCheck)
+				hits <- hit{imagetype, hoursAgo, imageUrl, checkRemoteFile(imageUrl)}
 			}(imagetype, hoursAgo)
 		}
 	}
@@ -65,29 +94,62 @@ func (s *SWXCOFiles) getImagePaths() map[string]string {
 	close(hits)
 
 	best := make(map[string]int)
+	netErrByType := make(map[string]bool)
 	for h := range hits {
-		if existing, ok := best[h.imagetype]; !ok || h.hoursAgo < existing {
-			best[h.imagetype] = h.hoursAgo
-			s.imagePaths[h.imagetype] = h.url
+		switch h.result {
+		case probeFound:
+			if existing, ok := best[h.imagetype]; !ok || h.hoursAgo < existing {
+				best[h.imagetype] = h.hoursAgo
+				s.imagePaths[h.imagetype] = h.url
+			}
+		case probeNetErr:
+			netErrByType[h.imagetype] = true
 		}
 	}
+
+	now := time.Now().UTC()
+	wuMu.Lock()
+	defer wuMu.Unlock()
 	for _, imagetype := range s.images {
-		if _, ok := s.imagePaths[imagetype]; !ok {
-			s.imagePaths[imagetype] = ""
+		if url, ok := s.imagePaths[imagetype]; ok && url != "" {
+			wuLastGoodURLs[imagetype] = wuCacheEntry{url: url, at: now}
+			continue
 		}
+		if netErrByType[imagetype] {
+			if lg, ok := wuLastGoodURLs[imagetype]; ok && now.Sub(lg.at) < wuLastGoodMaxAge {
+				s.imagePaths[imagetype] = lg.url
+				continue
+			}
+			s.imagePaths[imagetype] = s.urlFor(imagetype, s.runtime)
+			continue
+		}
+		s.imagePaths[imagetype] = ""
 	}
 	return s.imagePaths
 }
 
-func checkRemoteFile(url string) bool {
+func (s *SWXCOFiles) urlFor(imagetype string, t time.Time) string {
+	return fmt.Sprintf("%s/%s/%s/%s00z.jpg",
+		s.prefix,
+		imagetype,
+		t.Format("20060102"),
+		t.Format("15"))
+}
+
+func checkRemoteFile(url string) probeResult {
 	resp, err := imageCheckClient.Head(url)
 	if err != nil {
-		return false
+		// HEAD doesn't return err for HTTP statuses — any error here is a
+		// transport-level failure (DNS, timeout, TCP reset, TLS handshake).
+		return probeNetErr
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-	return resp.StatusCode == http.StatusOK
+	if resp.StatusCode == http.StatusOK {
+		return probeFound
+	}
+	return probeMissing
 }
 
 func HandleTemperatures(w http.ResponseWriter, r *http.Request) error {
@@ -118,16 +180,39 @@ func HandleTemperatures(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-// HandleWUTemperatureImages probes the Weather Underground static-map host
-// in parallel and returns the most recent available image URL per region as JSON.
-// Missing/stale regions come back with an empty string so the client can render
-// a failure state.
+// HandleWUTemperatureImages probes the Weather Underground static-map host in
+// parallel and returns the most recent available image URL per region as JSON.
+// Results are memoized for wuResultTTL to keep the fan-out off the hot path.
 func HandleWUTemperatureImages(w http.ResponseWriter, r *http.Request) error {
-	paths := NewSWXCOFiles().getImagePaths()
+	paths := cachedWUPaths()
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	if err := json.NewEncoder(w).Encode(paths); err != nil {
 		return middleware.InternalError(fmt.Errorf("failed to encode WU image paths: %w", err))
 	}
 	return nil
+}
+
+func cachedWUPaths() map[string]string {
+	wuMu.Lock()
+	if wuResult != nil && time.Since(wuResultAt) < wuResultTTL {
+		paths := make(map[string]string, len(wuResult))
+		for k, v := range wuResult {
+			paths[k] = v
+		}
+		wuMu.Unlock()
+		return paths
+	}
+	wuMu.Unlock()
+
+	paths := NewSWXCOFiles().getImagePaths()
+
+	wuMu.Lock()
+	wuResult = make(map[string]string, len(paths))
+	for k, v := range paths {
+		wuResult[k] = v
+	}
+	wuResultAt = time.Now()
+	wuMu.Unlock()
+	return paths
 }

--- a/internal/handlers/temperatures_test.go
+++ b/internal/handlers/temperatures_test.go
@@ -4,12 +4,150 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"wichitaradar/internal/middleware"
 	"wichitaradar/internal/testutils"
 	"wichitaradar/pkg/templates"
 )
+
+func resetWUCache() {
+	wuMu.Lock()
+	defer wuMu.Unlock()
+	wuResult = nil
+	wuResultAt = time.Time{}
+	wuLastGoodURLs = map[string]wuCacheEntry{}
+}
+
+func newTestSWXCO(prefix string) *SWXCOFiles {
+	return &SWXCOFiles{
+		runtime:     time.Now().UTC(),
+		prefix:      prefix,
+		images:      []string{"usa", "ddc"},
+		imagePaths:  make(map[string]string),
+		maxHoursAgo: 3,
+	}
+}
+
+func TestGetImagePaths_FoundReturnsURL(t *testing.T) {
+	resetWUCache()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := newTestSWXCO(srv.URL)
+	paths := s.getImagePaths()
+	for _, k := range s.images {
+		if !strings.HasPrefix(paths[k], srv.URL) {
+			t.Errorf("%s: expected URL under %s, got %q", k, srv.URL, paths[k])
+		}
+	}
+}
+
+func TestGetImagePaths_CleanMissReturnsEmpty(t *testing.T) {
+	resetWUCache()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	s := newTestSWXCO(srv.URL)
+	paths := s.getImagePaths()
+	for _, k := range s.images {
+		if paths[k] != "" {
+			t.Errorf("%s: expected empty string on clean miss, got %q", k, paths[k])
+		}
+	}
+}
+
+func TestGetImagePaths_NetErrorFallsBackToCurrentHour(t *testing.T) {
+	resetWUCache()
+	// Port 1 reliably refuses connections → probeNetErr for every probe.
+	s := newTestSWXCO("http://127.0.0.1:1")
+	paths := s.getImagePaths()
+	for _, k := range s.images {
+		want := s.urlFor(k, s.runtime)
+		if paths[k] != want {
+			t.Errorf("%s: expected current-hour fallback %q, got %q", k, want, paths[k])
+		}
+	}
+}
+
+func TestGetImagePaths_NetErrorPrefersLastGood(t *testing.T) {
+	resetWUCache()
+	wuMu.Lock()
+	wuLastGoodURLs["usa"] = wuCacheEntry{url: "https://example.invalid/usa-last-good.jpg", at: time.Now().UTC()}
+	wuMu.Unlock()
+
+	s := newTestSWXCO("http://127.0.0.1:1")
+	paths := s.getImagePaths()
+	if paths["usa"] != "https://example.invalid/usa-last-good.jpg" {
+		t.Errorf("usa: expected last-good URL, got %q", paths["usa"])
+	}
+	// ddc has no last-good → current-hour fallback
+	if paths["ddc"] != s.urlFor("ddc", s.runtime) {
+		t.Errorf("ddc: expected current-hour fallback, got %q", paths["ddc"])
+	}
+}
+
+func TestGetImagePaths_StaleLastGoodIgnored(t *testing.T) {
+	resetWUCache()
+	wuMu.Lock()
+	wuLastGoodURLs["usa"] = wuCacheEntry{
+		url: "https://example.invalid/usa-stale.jpg",
+		at:  time.Now().UTC().Add(-wuLastGoodMaxAge - time.Minute),
+	}
+	wuMu.Unlock()
+
+	s := newTestSWXCO("http://127.0.0.1:1")
+	paths := s.getImagePaths()
+	if paths["usa"] == "https://example.invalid/usa-stale.jpg" {
+		t.Errorf("usa: expected stale last-good to be ignored")
+	}
+	if paths["usa"] != s.urlFor("usa", s.runtime) {
+		t.Errorf("usa: expected current-hour fallback, got %q", paths["usa"])
+	}
+}
+
+func TestCachedWUPaths_MemoizesResult(t *testing.T) {
+	resetWUCache()
+	var hits int32
+	var hitsMu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitsMu.Lock()
+		hits++
+		hitsMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Seed the cache by running a probe directly and stashing the result.
+	s := newTestSWXCO(srv.URL)
+	paths := s.getImagePaths()
+	wuMu.Lock()
+	wuResult = paths
+	wuResultAt = time.Now()
+	wuMu.Unlock()
+
+	hitsMu.Lock()
+	before := hits
+	hitsMu.Unlock()
+
+	for i := 0; i < 3; i++ {
+		_ = cachedWUPaths()
+	}
+
+	hitsMu.Lock()
+	after := hits
+	hitsMu.Unlock()
+	if after != before {
+		t.Errorf("expected 0 additional upstream hits while cache fresh, got %d", after-before)
+	}
+}
 
 func TestHandleTemperatures(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

The `/api/wu-temperature-images` endpoint fans out 24 concurrent HEAD probes against `s.w-x.co` every time the temperatures page loads, and treats any probe error as "image missing." That conflates two very different failure modes:

- **Clean HTTP miss** (404) — the image genuinely isn't there yet for that hour.
- **Transport error** (DNS flake, timeout, TCP reset) — the image probably exists, but our server-side resolver couldn't reach it.

In the second case the slot renders as "failed" even though the user's browser would have loaded the image fine with its own resolver. This PR fixes that, and also memoizes the probe result to stop re-running the 24-probe fan-out on every request.

## Changes

**Tri-state probe.** `checkRemoteFile` now returns `probeFound` / `probeMissing` / `probeNetErr` instead of a bare `bool`. `HEAD` doesn't surface HTTP statuses as errors, so any non-nil error from the client is necessarily transport-level.

**Network-error fallback.** In `getImagePaths`, if a region has no 200 hit but at least one probe failed with a network error, the handler substitutes:

1. The last known-good URL for that region, if it's less than 3 hours old, or
2. The current-hour URL, so the browser still gets something to try.

Clean 404s still return `""` — we're only masking server-side resolver failures, not real upstream retirements.

**10-minute result cache.** `cachedWUPaths` memoizes the full result map for 10 minutes. Two benefits: kills the 24-HEAD fan-out on the hot path, and smooths over transient upstream blips between cache refreshes.

## Test plan

New tests in `temperatures_test.go` cover the branch logic that can't be exercised via the existing page-render tests:

- `TestGetImagePaths_FoundReturnsURL` — 200 response yields a URL under the test server prefix.
- `TestGetImagePaths_CleanMissReturnsEmpty` — 404 response yields `""` (no masking).
- `TestGetImagePaths_NetErrorFallsBackToCurrentHour` — connection refused with no cache falls back to the current-hour URL.
- `TestGetImagePaths_NetErrorPrefersLastGood` — connection refused with a fresh last-good entry uses it in preference to the current-hour URL.
- `TestGetImagePaths_StaleLastGoodIgnored` — last-good older than `wuLastGoodMaxAge` is ignored.
- `TestCachedWUPaths_MemoizesResult` — repeated calls within the TTL don't re-probe upstream.

All tests pass with `-race`. Existing `TestHandleTemperatures` is unchanged.

## Background

Investigation started from upstream images intermittently rendering as failed. I probed every URL on the temperatures page — all return HTTP 200 with fresh `last-modified` headers, so nothing is retired. The WU images do come back with `content-type: binary/octet-stream` and `fastly-io-error: response is pass` (Fastly's image optimizer rejected them at ingest), but browsers sniff and render `<img>` bytes regardless, so that's not the user-visible failure. The actual failure is server-side DNS flakiness at probe time — which this PR addresses.

---

[![Compound Engineering v2.60.0](https://img.shields.io/badge/Compound_Engineering-v2.60.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)