### PR TITLE
Add /alerts and /flooding pages, plus small fixes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  }
+}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,7 @@ linters-settings:
       - G114  # HTTP server without timeouts (production uses reverse proxy)
       - G301  # Directory permissions (0755 is standard for cache/log dirs)
       - G304  # File path from variable (sanitized via filepath package)
+      - G203  # template.JS on internally-marshaled JSON (no user input in raw JS sink)
 
 issues:
   # Exclude some linters from running on tests files

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -52,6 +52,7 @@ func setupServer(workDir string, skipTemplates bool) error {
 		cache.GetXMLCacheDir(projectRoot),
 		cache.GetAnimatedCacheDir(projectRoot),
 		cache.GetSPCCacheDir(projectRoot),
+		cache.GetFloodingCacheDir(projectRoot),
 	}
 
 	for _, dir := range cacheDirs {
@@ -63,6 +64,9 @@ func setupServer(workDir string, skipTemplates bool) error {
 	// Create Cache instances
 	xmlCache := cache.NewFileCache(cache.GetXMLCacheDir(projectRoot), 5*time.Minute)
 	spcCache := cache.NewFileCache(cache.GetSPCCacheDir(projectRoot), 30*time.Minute)
+	floodAlertCache := cache.NewFileCache(filepath.Join(cache.GetFloodingCacheDir(projectRoot), "alerts"), 2*time.Minute)
+	floodGaugeCache := cache.NewFileCache(filepath.Join(cache.GetFloodingCacheDir(projectRoot), "gauges"), 5*time.Minute)
+	floodClosureCache := cache.NewFileCache(filepath.Join(cache.GetFloodingCacheDir(projectRoot), "closures"), 2*time.Minute)
 
 	// Initialize image failure monitoring background sweeper
 	handlers.InitImageFailureMonitor()
@@ -90,6 +94,7 @@ func setupServer(workDir string, skipTemplates bool) error {
 	mux.Handle("/rainfall", middleware.ErrorHandler(handlers.HandleRainfall))
 	mux.Handle("/satellite", middleware.ErrorHandler(handlers.HandleSatellite))
 	mux.Handle("/outlook", middleware.ErrorHandler(handlers.HandleOutlook(xmlCache, spcCache)))
+	mux.Handle("/flooding", middleware.ErrorHandler(handlers.HandleFlooding(floodAlertCache, floodGaugeCache, floodClosureCache)))
 	mux.Handle("/watches", middleware.ErrorHandler(handlers.HandleSimplePage("watches")))
 	mux.Handle("/resources", middleware.ErrorHandler(handlers.HandleSimplePage("resources")))
 	mux.Handle("/about", middleware.ErrorHandler(handlers.HandleSimplePage("about")))

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,7 +64,7 @@ func setupServer(workDir string, skipTemplates bool) error {
 	// Create Cache instances
 	xmlCache := cache.NewFileCache(cache.GetXMLCacheDir(projectRoot), 5*time.Minute)
 	spcCache := cache.NewFileCache(cache.GetSPCCacheDir(projectRoot), 30*time.Minute)
-	floodAlertCache := cache.NewFileCache(filepath.Join(cache.GetFloodingCacheDir(projectRoot), "alerts"), 2*time.Minute)
+	alertsCache := cache.NewFileCache(filepath.Join(cache.GetFloodingCacheDir(projectRoot), "alerts"), 2*time.Minute)
 	floodGaugeCache := cache.NewFileCache(filepath.Join(cache.GetFloodingCacheDir(projectRoot), "gauges"), 5*time.Minute)
 	floodClosureCache := cache.NewFileCache(filepath.Join(cache.GetFloodingCacheDir(projectRoot), "closures"), 2*time.Minute)
 
@@ -94,8 +94,9 @@ func setupServer(workDir string, skipTemplates bool) error {
 	mux.Handle("/rainfall", middleware.ErrorHandler(handlers.HandleRainfall))
 	mux.Handle("/satellite", middleware.ErrorHandler(handlers.HandleSatellite))
 	mux.Handle("/outlook", middleware.ErrorHandler(handlers.HandleOutlook(xmlCache, spcCache)))
-	mux.Handle("/flooding", middleware.ErrorHandler(handlers.HandleFlooding(floodAlertCache, floodGaugeCache, floodClosureCache)))
+	mux.Handle("/flooding", middleware.ErrorHandler(handlers.HandleFlooding(alertsCache, floodGaugeCache, floodClosureCache)))
 	mux.Handle("/watches", middleware.ErrorHandler(handlers.HandleSimplePage("watches")))
+	mux.Handle("/alerts", middleware.ErrorHandler(handlers.HandleAlerts(alertsCache)))
 	mux.Handle("/resources", middleware.ErrorHandler(handlers.HandleSimplePage("resources")))
 	mux.Handle("/about", middleware.ErrorHandler(handlers.HandleSimplePage("about")))
 	mux.Handle("/disclaimer", middleware.ErrorHandler(handlers.HandleSimplePage("disclaimer")))

--- a/internal/cache/directories.go
+++ b/internal/cache/directories.go
@@ -36,3 +36,8 @@ func GetTempCacheDir(projectRoot string) string {
 func GetSPCCacheDir(projectRoot string) string {
 	return filepath.Join(projectRoot, "scraped", "spc")
 }
+
+// GetFloodingCacheDir returns the path to the flooding data cache directory
+func GetFloodingCacheDir(projectRoot string) string {
+	return filepath.Join(projectRoot, "scraped", "flooding")
+}

--- a/internal/handlers/alerts.go
+++ b/internal/handlers/alerts.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"wichitaradar/internal/cache"
+	"wichitaradar/internal/middleware"
+	"wichitaradar/menu"
+	"wichitaradar/pkg/templates"
+)
+
+// AlertsData is the template payload for the /alerts page.
+type AlertsData struct {
+	Menu            *menu.Menu
+	CurrentPath     string
+	RefreshInterval int
+
+	Available   bool
+	Alerts      []Alert
+	GeneratedAt string
+}
+
+// alertCategoryRank classifies an alert event for sort + banner color. Higher
+// is more urgent. This complements flooding.go's flood-only severityRank so the
+// /alerts page can rank ALL hazard types consistently.
+func alertCategoryRank(event string) int {
+	e := strings.ToLower(event)
+	switch {
+	case strings.Contains(e, "tornado warning"),
+		strings.Contains(e, "flash flood warning"),
+		strings.Contains(e, "extreme"):
+		return 4
+	case strings.Contains(e, "warning"):
+		return 3
+	case strings.Contains(e, "watch"):
+		return 2
+	case strings.Contains(e, "advisory"),
+		strings.Contains(e, "statement"),
+		strings.Contains(e, "alert"),
+		strings.Contains(e, "outlook"):
+		return 1
+	}
+	return 0
+}
+
+func parseAllNWSAlerts(r io.Reader) ([]Alert, error) {
+	var resp nwsAlertsResponse
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+
+	loc, _ := time.LoadLocation("America/Chicago")
+	alerts := make([]Alert, 0, len(resp.Features))
+
+	for _, raw := range resp.Features {
+		var f nwsAlertFeature
+		if err := json.Unmarshal(raw, &f); err != nil {
+			continue
+		}
+		expires := ""
+		if !f.Properties.Expires.IsZero() {
+			expires = f.Properties.Expires.In(loc).Format("Mon 3:04 PM MST")
+		}
+		sent := ""
+		if !f.Properties.Sent.IsZero() {
+			sent = f.Properties.Sent.In(loc).Format("Mon 3:04 PM MST")
+		}
+		alerts = append(alerts, Alert{
+			Event:        f.Properties.Event,
+			Headline:     f.Properties.Headline,
+			Severity:     f.Properties.Severity,
+			Description:  f.Properties.Description,
+			AreaDesc:     f.Properties.AreaDesc,
+			Expires:      expires,
+			Sent:         sent,
+			SeverityRank: alertCategoryRank(f.Properties.Event),
+		})
+	}
+
+	sort.SliceStable(alerts, func(i, j int) bool {
+		return alerts[i].SeverityRank > alerts[j].SeverityRank
+	})
+	return alerts, nil
+}
+
+// HandleAlerts returns the /alerts handler. It shares the alertsCache used by
+// /flooding so both pages hit api.weather.gov at most once per cache TTL.
+func HandleAlerts(alertsCache cache.CacheProvider) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		data := AlertsData{
+			Menu:            menu.New(),
+			CurrentPath:     r.URL.Path,
+			RefreshInterval: 300,
+		}
+
+		const alertURL = "https://api.weather.gov/alerts/active?zone=KSC173"
+		if ar, err := alertsCache.GetContent(alertURL, "", "alerts-ksc173.json"); err == nil {
+			alerts, perr := parseAllNWSAlerts(ar)
+			_ = ar.Close()
+			if perr == nil {
+				data.Alerts = alerts
+				data.Available = true
+			}
+		}
+
+		loc, _ := time.LoadLocation("America/Chicago")
+		data.GeneratedAt = time.Now().In(loc).Format("Mon Jan 2 3:04:05 PM MST")
+
+		ts, err := templates.Get("alerts")
+		if err != nil {
+			return middleware.InternalError(fmt.Errorf("failed to get template set 'alerts': %w", err))
+		}
+		if err := ts.ExecuteTemplate(w, "alerts", data); err != nil {
+			return middleware.InternalError(fmt.Errorf("failed to render template 'alerts': %w", err))
+		}
+		return nil
+	}
+}

--- a/internal/handlers/flooding.go
+++ b/internal/handlers/flooding.go
@@ -54,13 +54,13 @@ var gaugesForWichita = []floodGauge{
 
 // Alert is a normalized NWS flood alert ready for display.
 type Alert struct {
-	Event       string
-	Headline    string
-	Severity    string
-	Description string
-	AreaDesc    string
-	Expires     string
-	Sent        string
+	Event        string
+	Headline     string
+	Severity     string
+	Description  string
+	AreaDesc     string
+	Expires      string
+	Sent         string
 	SeverityRank int
 }
 
@@ -227,10 +227,18 @@ type nwpsGaugeResponse struct {
 	Flood struct {
 		StageUnits string `json:"stageUnits"`
 		Categories struct {
-			Action   struct{ Stage float64 `json:"stage"` } `json:"action"`
-			Minor    struct{ Stage float64 `json:"stage"` } `json:"minor"`
-			Moderate struct{ Stage float64 `json:"stage"` } `json:"moderate"`
-			Major    struct{ Stage float64 `json:"stage"` } `json:"major"`
+			Action struct {
+				Stage float64 `json:"stage"`
+			} `json:"action"`
+			Minor struct {
+				Stage float64 `json:"stage"`
+			} `json:"minor"`
+			Moderate struct {
+				Stage float64 `json:"stage"`
+			} `json:"moderate"`
+			Major struct {
+				Stage float64 `json:"stage"`
+			} `json:"major"`
 		} `json:"categories"`
 	} `json:"flood"`
 }
@@ -282,7 +290,7 @@ func parseNWPSGauge(r io.Reader, g floodGauge) Gauge {
 		status = categorize(resp.Status.Observed.Primary, resp)
 	}
 	// Normalize casing: NWPS sometimes returns "minor" / "no_flooding".
-	status = strings.Title(strings.ReplaceAll(strings.ToLower(status), "_", " "))
+	status = titleCase(strings.ReplaceAll(strings.ToLower(status), "_", " "))
 	if status == "" || status == "No Flooding" {
 		status = "None"
 	}
@@ -329,6 +337,22 @@ func parseNWPSGauge(r io.Reader, g floodGauge) Gauge {
 		FloodStage: floodStage,
 		Observed:   observed,
 	}
+}
+
+func titleCase(s string) string {
+	b := []byte(s)
+	upper := true
+	for i, c := range b {
+		if c == ' ' {
+			upper = true
+			continue
+		}
+		if upper && c >= 'a' && c <= 'z' {
+			b[i] = c - 32
+		}
+		upper = false
+	}
+	return string(b)
 }
 
 func gaugesGeoJSON(gauges []Gauge) []byte {

--- a/internal/handlers/flooding.go
+++ b/internal/handlers/flooding.go
@@ -1,0 +1,581 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"wichitaradar/internal/cache"
+	"wichitaradar/internal/middleware"
+	"wichitaradar/menu"
+	"wichitaradar/pkg/templates"
+)
+
+// Severity ranks for picking the worst active condition.
+const (
+	sevNone     = 0
+	sevAdvisory = 1
+	sevWatch    = 2
+	sevWarning  = 3
+	sevFlash    = 4
+)
+
+// floodGauge describes one NWS/NWPS river gauge we display.
+type floodGauge struct {
+	ID   string  // NWPS LID, e.g. "ICTK1"
+	Name string  // Human-readable label
+	Lat  float64 // Decimal degrees
+	Lon  float64
+}
+
+// gaugesForWichita lists NWPS gauges in and around Sedgwick County (Arkansas
+// River, Little Arkansas, Cowskin, Ninnescah, Walnut basins). NWS does not
+// operate a flood-forecast gauge directly in Wichita on the Arkansas River
+// (Cheney Reservoir regulates upstream flow); upstream/downstream gauges plus
+// the Cowskin and Little Arkansas give the best picture of city-relevant flood
+// conditions. Coordinates come from the NWPS gauge metadata.
+var gaugesForWichita = []floodGauge{
+	{ID: "COWK1", Name: "Cowskin Creek at 119th St W, Wichita", Lat: 37.70169, Lon: -97.48055},
+	{ID: "DRBK1", Name: "Arkansas River at Derby", Lat: 37.54431, Lon: -97.27557},
+	{ID: "MULK1", Name: "Arkansas River near Mulvane", Lat: 37.4755, Lon: -97.2613},
+	{ID: "HAVK1", Name: "Arkansas River near Haven", Lat: 37.94614, Lon: -97.77512},
+	{ID: "SEDK1", Name: "Little Arkansas River near Sedgwick", Lat: 37.88305, Lon: -97.42416},
+	{ID: "HTDK1", Name: "Little Arkansas River near Halstead", Lat: 38.02853, Lon: -97.54054},
+	{ID: "ALMK1", Name: "Little Arkansas River at Alta Mills", Lat: 38.1122, Lon: -97.59194},
+	{ID: "BLPK1", Name: "Ninnescah River near Belle Plaine", Lat: 37.3916, Lon: -97.3391},
+	{ID: "PECK1", Name: "Ninnescah River near Peck", Lat: 37.4569, Lon: -97.4236},
+	{ID: "AGAK1", Name: "Walnut River at Augusta", Lat: 37.67056, Lon: -96.98},
+}
+
+// Alert is a normalized NWS flood alert ready for display.
+type Alert struct {
+	Event       string
+	Headline    string
+	Severity    string
+	Description string
+	AreaDesc    string
+	Expires     string
+	Sent        string
+	SeverityRank int
+}
+
+// Gauge is a normalized gauge reading ready for display.
+type Gauge struct {
+	ID         string
+	Name       string
+	Lat        float64
+	Lon        float64
+	Stage      string // Current observed stage, formatted (e.g., "4.21 ft")
+	Status     string // None / Action / Minor / Moderate / Major / Unknown
+	StatusRank int    // For sorting and worst-status computation
+	FloodStage string // e.g., "13.0 ft" (or "" if not provided)
+	Observed   string // Observation time
+	Trend      string // "Rising" / "Falling" / "Steady" / ""
+}
+
+// Closure is a normalized active road closure entry (flood or storm related)
+// sourced from Sedgwick County's public road-closure FeatureService.
+type Closure struct {
+	Street      string
+	Reason      string // "Flooding" / "Storm Damage"
+	Description string
+	City        string
+	Begin       string
+	End         string
+	AltRoute    string
+	StartedAt   string
+	Lat         float64
+	Lon         float64
+}
+
+// FloodingData is the template payload.
+type FloodingData struct {
+	Menu            *menu.Menu
+	CurrentPath     string
+	RefreshInterval int
+
+	BannerLevel       string // "none" / "advisory" / "watch" / "warning" / "flash"
+	BannerText        string
+	Alerts            []Alert
+	Gauges            []Gauge
+	Closures          []Closure
+	AlertsAvailable   bool
+	GaugesAvailable   bool
+	ClosuresAvailable bool
+
+	AlertsGeoJSON   template.JS
+	GaugesGeoJSON   template.JS
+	ClosuresGeoJSON template.JS
+
+	GeneratedAt string
+}
+
+// --- NWS alerts -----------------------------------------------------------
+
+type nwsAlertsResponse struct {
+	Features []json.RawMessage `json:"features"`
+}
+
+type nwsAlertFeature struct {
+	Geometry   json.RawMessage `json:"geometry"`
+	Properties struct {
+		Event       string    `json:"event"`
+		Headline    string    `json:"headline"`
+		Severity    string    `json:"severity"`
+		Description string    `json:"description"`
+		AreaDesc    string    `json:"areaDesc"`
+		Sent        time.Time `json:"sent"`
+		Expires     time.Time `json:"expires"`
+	} `json:"properties"`
+}
+
+func severityRank(event string) int {
+	e := strings.ToLower(event)
+	switch {
+	case strings.Contains(e, "flash flood warning"):
+		return sevFlash
+	case strings.Contains(e, "flood warning"):
+		return sevWarning
+	case strings.Contains(e, "flood watch"), strings.Contains(e, "flash flood watch"):
+		return sevWatch
+	case strings.Contains(e, "flood advisory"), strings.Contains(e, "hydrologic"):
+		return sevAdvisory
+	}
+	return sevNone
+}
+
+func parseNWSAlerts(r io.Reader) ([]Alert, json.RawMessage, error) {
+	var resp nwsAlertsResponse
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, nil, err
+	}
+
+	loc, _ := time.LoadLocation("America/Chicago")
+	alerts := make([]Alert, 0, len(resp.Features))
+	geomFeatures := make([]json.RawMessage, 0, len(resp.Features))
+
+	for _, raw := range resp.Features {
+		var f nwsAlertFeature
+		if err := json.Unmarshal(raw, &f); err != nil {
+			continue
+		}
+		rank := severityRank(f.Properties.Event)
+		if rank == sevNone {
+			continue
+		}
+		expires := ""
+		if !f.Properties.Expires.IsZero() {
+			expires = f.Properties.Expires.In(loc).Format("Mon 3:04 PM MST")
+		}
+		sent := ""
+		if !f.Properties.Sent.IsZero() {
+			sent = f.Properties.Sent.In(loc).Format("Mon 3:04 PM MST")
+		}
+		alerts = append(alerts, Alert{
+			Event:        f.Properties.Event,
+			Headline:     f.Properties.Headline,
+			Severity:     f.Properties.Severity,
+			Description:  f.Properties.Description,
+			AreaDesc:     f.Properties.AreaDesc,
+			Expires:      expires,
+			Sent:         sent,
+			SeverityRank: rank,
+		})
+		geomFeatures = append(geomFeatures, raw)
+	}
+
+	sort.SliceStable(alerts, func(i, j int) bool {
+		return alerts[i].SeverityRank > alerts[j].SeverityRank
+	})
+
+	geo := struct {
+		Type     string            `json:"type"`
+		Features []json.RawMessage `json:"features"`
+	}{
+		Type:     "FeatureCollection",
+		Features: geomFeatures,
+	}
+	geoJSON, _ := json.Marshal(geo)
+	return alerts, geoJSON, nil
+}
+
+// --- NWPS gauges ----------------------------------------------------------
+
+// nwpsGaugeResponse models the subset of NWPS /gauges/{id} we use. The API
+// returns flood-stage thresholds (nested under flood.categories) and the most
+// recent observation.
+type nwpsGaugeResponse struct {
+	LID    string `json:"lid"`
+	Name   string `json:"name"`
+	Status struct {
+		Observed struct {
+			Primary       float64 `json:"primary"`
+			PrimaryUnit   string  `json:"primaryUnit"`
+			ValidTime     string  `json:"validTime"`
+			FloodCategory string  `json:"floodCategory"`
+		} `json:"observed"`
+	} `json:"status"`
+	Flood struct {
+		StageUnits string `json:"stageUnits"`
+		Categories struct {
+			Action   struct{ Stage float64 `json:"stage"` } `json:"action"`
+			Minor    struct{ Stage float64 `json:"stage"` } `json:"minor"`
+			Moderate struct{ Stage float64 `json:"stage"` } `json:"moderate"`
+			Major    struct{ Stage float64 `json:"stage"` } `json:"major"`
+		} `json:"categories"`
+	} `json:"flood"`
+}
+
+func statusRank(s string) int {
+	switch strings.ToLower(s) {
+	case "major":
+		return 4
+	case "moderate":
+		return 3
+	case "minor":
+		return 2
+	case "action":
+		return 1
+	case "":
+		return 0
+	case "no flooding", "none":
+		return 0
+	}
+	return 0
+}
+
+func categorize(stage float64, c nwpsGaugeResponse) string {
+	switch {
+	case c.Flood.Categories.Major.Stage > 0 && stage >= c.Flood.Categories.Major.Stage:
+		return "Major"
+	case c.Flood.Categories.Moderate.Stage > 0 && stage >= c.Flood.Categories.Moderate.Stage:
+		return "Moderate"
+	case c.Flood.Categories.Minor.Stage > 0 && stage >= c.Flood.Categories.Minor.Stage:
+		return "Minor"
+	case c.Flood.Categories.Action.Stage > 0 && stage >= c.Flood.Categories.Action.Stage:
+		return "Action"
+	}
+	return "None"
+}
+
+func parseNWPSGauge(r io.Reader, g floodGauge) Gauge {
+	var resp nwpsGaugeResponse
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return Gauge{ID: g.ID, Name: g.Name, Lat: g.Lat, Lon: g.Lon, Status: "Unknown"}
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return Gauge{ID: g.ID, Name: g.Name, Lat: g.Lat, Lon: g.Lon, Status: "Unknown"}
+	}
+
+	status := resp.Status.Observed.FloodCategory
+	if status == "" || strings.EqualFold(status, "no_flooding") {
+		status = categorize(resp.Status.Observed.Primary, resp)
+	}
+	// Normalize casing: NWPS sometimes returns "minor" / "no_flooding".
+	status = strings.Title(strings.ReplaceAll(strings.ToLower(status), "_", " "))
+	if status == "" || status == "No Flooding" {
+		status = "None"
+	}
+
+	// NWPS uses -999 as a sentinel for "no current observation".
+	stage := ""
+	primary := resp.Status.Observed.Primary
+	if primary > -900 && (primary != 0 || resp.Status.Observed.PrimaryUnit != "") {
+		unit := resp.Status.Observed.PrimaryUnit
+		if unit == "" {
+			unit = "ft"
+		}
+		stage = fmt.Sprintf("%.2f %s", primary, unit)
+	} else {
+		status = "Unknown"
+	}
+
+	floodStage := ""
+	unit := resp.Flood.StageUnits
+	if unit == "" {
+		unit = "ft"
+	}
+	if resp.Flood.Categories.Minor.Stage > 0 {
+		floodStage = fmt.Sprintf("%.1f %s", resp.Flood.Categories.Minor.Stage, unit)
+	}
+
+	observed := ""
+	if t, err := time.Parse(time.RFC3339, resp.Status.Observed.ValidTime); err == nil {
+		if loc, err := time.LoadLocation("America/Chicago"); err == nil {
+			observed = t.In(loc).Format("Mon 3:04 PM MST")
+		} else {
+			observed = t.Format("Mon 15:04 MST")
+		}
+	}
+
+	return Gauge{
+		ID:         g.ID,
+		Name:       g.Name,
+		Lat:        g.Lat,
+		Lon:        g.Lon,
+		Stage:      stage,
+		Status:     status,
+		StatusRank: statusRank(status),
+		FloodStage: floodStage,
+		Observed:   observed,
+	}
+}
+
+func gaugesGeoJSON(gauges []Gauge) []byte {
+	type feature struct {
+		Type     string `json:"type"`
+		Geometry struct {
+			Type        string    `json:"type"`
+			Coordinates []float64 `json:"coordinates"`
+		} `json:"geometry"`
+		Properties map[string]any `json:"properties"`
+	}
+	type collection struct {
+		Type     string    `json:"type"`
+		Features []feature `json:"features"`
+	}
+	c := collection{Type: "FeatureCollection"}
+	for _, g := range gauges {
+		f := feature{Type: "Feature"}
+		f.Geometry.Type = "Point"
+		f.Geometry.Coordinates = []float64{g.Lon, g.Lat}
+		f.Properties = map[string]any{
+			"id":         g.ID,
+			"name":       g.Name,
+			"stage":      g.Stage,
+			"status":     g.Status,
+			"floodStage": g.FloodStage,
+			"observed":   g.Observed,
+		}
+		c.Features = append(c.Features, f)
+	}
+	out, _ := json.Marshal(c)
+	return out
+}
+
+// --- Sedgwick County road closures ---------------------------------------
+
+// closuresQueryURL is the Sedgwick County Public Works road-closure
+// FeatureServer query, filtered to currently-in-progress flood and
+// storm-damage closures (Status=2 means in progress per the layer's coded
+// domain; 1=planned, 3=completed). Coverage includes the city of Wichita.
+const closuresQueryURL = "https://services7.arcgis.com/McLat6HlPl45bNBv/arcgis/rest/services/Public_PW_RoadClosures_WGS84/FeatureServer/0/query" +
+	"?where=Status%3D2+AND+subtype+IN+%28%27ROAD_CLOSED_FLOOD%27%2C%27ROAD_CLOSED_STORM_DAMAGE%27%29" +
+	"&outFields=street%2Csubtype%2Cdescription%2Cdirection%2Cstarttime%2Caltroute%2CCity%2CBeginBoundary%2CEndBoundary" +
+	"&returnGeometry=true&outSR=4326&f=json"
+
+// subtypeLabel maps the layer's coded subtype values to display labels.
+var subtypeLabel = map[string]string{
+	"ROAD_CLOSED_FLOOD":        "Flooding",
+	"ROAD_CLOSED_STORM_DAMAGE": "Storm Damage",
+}
+
+type arcgisClosureResponse struct {
+	Features []struct {
+		Attributes struct {
+			Street        string `json:"street"`
+			Subtype       string `json:"subtype"`
+			Description   string `json:"description"`
+			Direction     string `json:"direction"`
+			StartTime     int64  `json:"starttime"` // epoch millis
+			AltRoute      string `json:"altroute"`
+			City          string `json:"City"`
+			BeginBoundary string `json:"BeginBoundary"`
+			EndBoundary   string `json:"EndBoundary"`
+		} `json:"attributes"`
+		Geometry struct {
+			X float64 `json:"x"`
+			Y float64 `json:"y"`
+		} `json:"geometry"`
+	} `json:"features"`
+}
+
+func parseClosures(r io.Reader) ([]Closure, error) {
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var resp arcgisClosureResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	loc, _ := time.LoadLocation("America/Chicago")
+	out := make([]Closure, 0, len(resp.Features))
+	for _, f := range resp.Features {
+		a := f.Attributes
+		reason := subtypeLabel[a.Subtype]
+		if reason == "" {
+			reason = a.Subtype
+		}
+		started := ""
+		if a.StartTime > 0 {
+			started = time.UnixMilli(a.StartTime).In(loc).Format("Mon Jan 2, 3:04 PM MST")
+		}
+		out = append(out, Closure{
+			Street:      a.Street,
+			Reason:      reason,
+			Description: a.Description,
+			City:        a.City,
+			Begin:       a.BeginBoundary,
+			End:         a.EndBoundary,
+			AltRoute:    a.AltRoute,
+			StartedAt:   started,
+			Lat:         f.Geometry.Y,
+			Lon:         f.Geometry.X,
+		})
+	}
+	return out, nil
+}
+
+func closuresGeoJSON(closures []Closure) []byte {
+	type feature struct {
+		Type     string `json:"type"`
+		Geometry struct {
+			Type        string    `json:"type"`
+			Coordinates []float64 `json:"coordinates"`
+		} `json:"geometry"`
+		Properties map[string]any `json:"properties"`
+	}
+	type collection struct {
+		Type     string    `json:"type"`
+		Features []feature `json:"features"`
+	}
+	c := collection{Type: "FeatureCollection"}
+	for _, cl := range closures {
+		if cl.Lat == 0 && cl.Lon == 0 {
+			continue
+		}
+		f := feature{Type: "Feature"}
+		f.Geometry.Type = "Point"
+		f.Geometry.Coordinates = []float64{cl.Lon, cl.Lat}
+		f.Properties = map[string]any{
+			"street":      cl.Street,
+			"reason":      cl.Reason,
+			"description": cl.Description,
+			"city":        cl.City,
+			"begin":       cl.Begin,
+			"end":         cl.End,
+			"altRoute":    cl.AltRoute,
+			"startedAt":   cl.StartedAt,
+		}
+		c.Features = append(c.Features, f)
+	}
+	out, _ := json.Marshal(c)
+	return out
+}
+
+// --- Handler --------------------------------------------------------------
+
+// HandleFlooding returns the /flooding handler.
+func HandleFlooding(alertCache, gaugeCache, closureCache cache.CacheProvider) func(http.ResponseWriter, *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		data := FloodingData{
+			Menu:            menu.New(),
+			CurrentPath:     r.URL.Path,
+			RefreshInterval: 300,
+		}
+
+		// --- Alerts (Sedgwick County, FIPS zone KSC173) ---
+		alertURL := "https://api.weather.gov/alerts/active?zone=KSC173"
+		if ar, err := alertCache.GetContent(alertURL, "", "alerts-ksc173.json"); err == nil {
+			alerts, geo, perr := parseNWSAlerts(ar)
+			_ = ar.Close()
+			if perr == nil {
+				data.Alerts = alerts
+				data.AlertsGeoJSON = template.JS(geo)
+				data.AlertsAvailable = true
+			}
+		}
+
+		// --- Gauges ---
+		gaugeReadings := make([]Gauge, 0, len(gaugesForWichita))
+		anyGauge := false
+		for _, g := range gaugesForWichita {
+			url := fmt.Sprintf("https://api.water.noaa.gov/nwps/v1/gauges/%s", strings.ToLower(g.ID))
+			gr, err := gaugeCache.GetContent(url, "", "gauge-"+strings.ToLower(g.ID)+".json")
+			if err != nil {
+				gaugeReadings = append(gaugeReadings, Gauge{ID: g.ID, Name: g.Name, Lat: g.Lat, Lon: g.Lon, Status: "Unknown"})
+				continue
+			}
+			gaugeReadings = append(gaugeReadings, parseNWPSGauge(gr, g))
+			_ = gr.Close()
+			anyGauge = true
+		}
+		data.Gauges = gaugeReadings
+		data.GaugesAvailable = anyGauge
+		data.GaugesGeoJSON = template.JS(gaugesGeoJSON(gaugeReadings))
+
+		// --- Closures (Sedgwick County, flood/storm subtypes, in-progress only) ---
+		if cr, err := closureCache.GetContent(closuresQueryURL, "", "closures-sgw.json"); err == nil {
+			closures, perr := parseClosures(cr)
+			_ = cr.Close()
+			if perr == nil {
+				data.Closures = closures
+				data.ClosuresAvailable = true
+				data.ClosuresGeoJSON = template.JS(closuresGeoJSON(closures))
+			}
+		}
+
+		// --- Banner ---
+		data.BannerLevel, data.BannerText = computeBanner(data.Alerts, data.Gauges)
+
+		loc, _ := time.LoadLocation("America/Chicago")
+		data.GeneratedAt = time.Now().In(loc).Format("Mon Jan 2 3:04:05 PM MST")
+
+		ts, err := templates.Get("flooding")
+		if err != nil {
+			return middleware.InternalError(fmt.Errorf("failed to get template set 'flooding': %w", err))
+		}
+		if err := ts.ExecuteTemplate(w, "flooding", data); err != nil {
+			return middleware.InternalError(fmt.Errorf("failed to render template 'flooding': %w", err))
+		}
+		return nil
+	}
+}
+
+func computeBanner(alerts []Alert, gauges []Gauge) (level, text string) {
+	worstAlert := 0
+	var worstAlertEvent string
+	for _, a := range alerts {
+		if a.SeverityRank > worstAlert {
+			worstAlert = a.SeverityRank
+			worstAlertEvent = a.Event
+		}
+	}
+	worstGauge := 0
+	var worstGaugeName string
+	for _, g := range gauges {
+		if g.StatusRank > worstGauge {
+			worstGauge = g.StatusRank
+			worstGaugeName = g.Name
+		}
+	}
+
+	switch {
+	case worstAlert >= sevFlash:
+		return "flash", fmt.Sprintf("A %s is in effect for Sedgwick County.", worstAlertEvent)
+	case worstAlert >= sevWarning:
+		return "warning", fmt.Sprintf("A %s is in effect for Sedgwick County.", worstAlertEvent)
+	case worstAlert >= sevWatch:
+		return "watch", fmt.Sprintf("A %s is in effect for Sedgwick County.", worstAlertEvent)
+	case worstAlert >= sevAdvisory:
+		return "advisory", fmt.Sprintf("A %s is in effect for Sedgwick County.", worstAlertEvent)
+	case worstGauge >= 3:
+		return "warning", fmt.Sprintf("%s is at moderate or major flood stage.", worstGaugeName)
+	case worstGauge == 2:
+		return "watch", fmt.Sprintf("%s is at minor flood stage.", worstGaugeName)
+	case worstGauge == 1:
+		return "advisory", fmt.Sprintf("%s is near action stage.", worstGaugeName)
+	}
+	return "none", "No flood alerts or warnings are currently in effect for Sedgwick County."
+}

--- a/internal/handlers/flooding_test.go
+++ b/internal/handlers/flooding_test.go
@@ -1,0 +1,242 @@
+package handlers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"wichitaradar/internal/testutils"
+)
+
+// stubCache returns a different canned response per filename prefix so we can
+// distinguish the alert call from individual gauge calls.
+type stubCache struct {
+	responses map[string]string // keyed by filename prefix
+	fallback  string
+}
+
+func (s *stubCache) GetContent(url, referer string, filename ...string) (io.ReadCloser, error) {
+	name := ""
+	if len(filename) > 0 {
+		name = filename[0]
+	}
+	for prefix, body := range s.responses {
+		if strings.HasPrefix(name, prefix) {
+			return io.NopCloser(strings.NewReader(body)), nil
+		}
+	}
+	if s.fallback != "" {
+		return io.NopCloser(strings.NewReader(s.fallback)), nil
+	}
+	return nil, fmt.Errorf("no stub for %s", name)
+}
+
+func TestSeverityRank(t *testing.T) {
+	cases := []struct {
+		event string
+		want  int
+	}{
+		{"Flash Flood Warning", sevFlash},
+		{"Flood Warning", sevWarning},
+		{"Flood Watch", sevWatch},
+		{"Flash Flood Watch", sevWatch},
+		{"Flood Advisory", sevAdvisory},
+		{"Tornado Warning", sevNone},
+	}
+	for _, c := range cases {
+		if got := severityRank(c.event); got != c.want {
+			t.Errorf("severityRank(%q) = %d, want %d", c.event, got, c.want)
+		}
+	}
+}
+
+func TestParseNWSAlerts(t *testing.T) {
+	body := `{
+	  "features": [
+	    {
+	      "geometry": {"type":"Polygon","coordinates":[[[-97.5,37.6],[-97.2,37.6],[-97.2,37.8],[-97.5,37.8],[-97.5,37.6]]]},
+	      "properties": {
+	        "event":"Flash Flood Warning",
+	        "headline":"Flash flooding likely",
+	        "severity":"Severe",
+	        "description":"Heavy rain producing flash flooding.",
+	        "areaDesc":"Sedgwick, KS",
+	        "sent":"2026-06-25T18:00:00+00:00",
+	        "expires":"2026-06-25T21:00:00+00:00"
+	      }
+	    },
+	    {
+	      "geometry": null,
+	      "properties": {
+	        "event":"Wind Advisory",
+	        "headline":"Windy",
+	        "severity":"Minor"
+	      }
+	    }
+	  ]
+	}`
+	alerts, geo, err := parseNWSAlerts(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseNWSAlerts error: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("got %d alerts, want 1", len(alerts))
+	}
+	if alerts[0].Event != "Flash Flood Warning" {
+		t.Errorf("event = %q", alerts[0].Event)
+	}
+	if alerts[0].SeverityRank != sevFlash {
+		t.Errorf("rank = %d", alerts[0].SeverityRank)
+	}
+	if !strings.Contains(string(geo), "FeatureCollection") {
+		t.Errorf("geojson missing FeatureCollection: %s", geo)
+	}
+}
+
+func TestParseNWPSGauge(t *testing.T) {
+	body := `{
+	  "lid":"ICTK1",
+	  "name":"Arkansas at Wichita",
+	  "status":{
+	    "observed":{"primary":14.2,"primaryUnit":"ft","validTime":"2026-06-25T18:00:00Z","floodCategory":"minor"}
+	  },
+	  "flood":{"stageUnits":"ft","categories":{"action":{"stage":11.0},"minor":{"stage":13.0},"moderate":{"stage":16.0},"major":{"stage":20.0}}}
+	}`
+	g := parseNWPSGauge(strings.NewReader(body), floodGauge{ID: "ICTK1", Name: "Arkansas at Wichita", Lat: 37.69, Lon: -97.34})
+	if g.Status != "Minor" {
+		t.Errorf("status = %q, want Minor", g.Status)
+	}
+	if !strings.HasPrefix(g.Stage, "14.20") {
+		t.Errorf("stage = %q", g.Stage)
+	}
+	if g.FloodStage != "13.0 ft" {
+		t.Errorf("flood stage = %q", g.FloodStage)
+	}
+	if g.StatusRank != 2 {
+		t.Errorf("rank = %d", g.StatusRank)
+	}
+}
+
+func TestParseNWPSGaugeCategorizesFromStage(t *testing.T) {
+	body := `{
+	  "lid":"X","name":"X",
+	  "status":{"observed":{"primary":17.0,"primaryUnit":"ft","validTime":"","floodCategory":""}},
+	  "flood":{"stageUnits":"ft","categories":{"action":{"stage":11.0},"minor":{"stage":13.0},"moderate":{"stage":16.0},"major":{"stage":20.0}}}
+	}`
+	g := parseNWPSGauge(strings.NewReader(body), floodGauge{ID: "X", Name: "X"})
+	if g.Status != "Moderate" {
+		t.Errorf("status = %q, want Moderate", g.Status)
+	}
+}
+
+func TestParseClosures(t *testing.T) {
+	body := `{"features":[
+	  {"attributes":{"street":"Lincoln St","subtype":"ROAD_CLOSED_FLOOD","description":"High water","direction":"E/W","starttime":1751823000000,"altroute":"Use Maple","City":"Wichita","BeginBoundary":"Hydraulic","EndBoundary":"I-135"},"geometry":{"x":-97.3,"y":37.65}},
+	  {"attributes":{"street":"K-42","subtype":"ROAD_CLOSED_STORM_DAMAGE","description":"Downed tree","City":"Haysville"},"geometry":{"x":-97.36,"y":37.55}}
+	]}`
+	got, err := parseClosures(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseClosures error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d closures, want 2", len(got))
+	}
+	if got[0].Reason != "Flooding" {
+		t.Errorf("first reason = %q, want Flooding", got[0].Reason)
+	}
+	if got[1].Reason != "Storm Damage" {
+		t.Errorf("second reason = %q, want Storm Damage", got[1].Reason)
+	}
+	if got[0].City != "Wichita" || got[0].Begin != "Hydraulic" {
+		t.Errorf("attributes not parsed: %+v", got[0])
+	}
+}
+
+func TestComputeBanner(t *testing.T) {
+	cases := []struct {
+		name      string
+		alerts    []Alert
+		gauges    []Gauge
+		wantLevel string
+	}{
+		{"none", nil, nil, "none"},
+		{"flash beats gauge", []Alert{{Event: "Flash Flood Warning", SeverityRank: sevFlash}}, []Gauge{{StatusRank: 4}}, "flash"},
+		{"gauge minor", nil, []Gauge{{Name: "Arkansas", StatusRank: 2}}, "watch"},
+		{"gauge action", nil, []Gauge{{Name: "Arkansas", StatusRank: 1}}, "advisory"},
+		{"warning", []Alert{{Event: "Flood Warning", SeverityRank: sevWarning}}, nil, "warning"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			lvl, _ := computeBanner(c.alerts, c.gauges)
+			if lvl != c.wantLevel {
+				t.Errorf("level = %q, want %q", lvl, c.wantLevel)
+			}
+		})
+	}
+}
+
+func TestHandleFloodingRenders(t *testing.T) {
+	testutils.InitTemplates(t)
+
+	alertBody := `{"features":[]}`
+	gaugeBody := `{
+	  "lid":"ICTK1","name":"Arkansas at Wichita",
+	  "status":{"observed":{"primary":4.21,"primaryUnit":"ft","validTime":"2026-06-25T18:00:00Z","floodCategory":"no_flooding"}},
+	  "flood":{"stageUnits":"ft","categories":{"action":{"stage":11.0},"minor":{"stage":13.0},"moderate":{"stage":16.0},"major":{"stage":20.0}}}
+	}`
+
+	closureBody := `{"features":[{"attributes":{"street":"K-15 / Hydraulic","subtype":"ROAD_CLOSED_FLOOD","description":"Standing water across roadway","direction":"N/S","starttime":1751823000000,"altroute":"Use Broadway","City":"Wichita","BeginBoundary":"31st St S","EndBoundary":"47th St S"},"geometry":{"x":-97.33,"y":37.62}}]}`
+
+	alertCache := &stubCache{responses: map[string]string{"alerts-": alertBody}}
+	gaugeCache := &stubCache{responses: map[string]string{"gauge-": gaugeBody}}
+	closureCache := &stubCache{responses: map[string]string{"closures-": closureBody}}
+
+	handler := HandleFlooding(alertCache, gaugeCache, closureCache)
+	req := httptest.NewRequest("GET", "/flooding", nil)
+	w := httptest.NewRecorder()
+
+	if err := handler(w, req); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d", w.Code)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"No flood alerts or warnings are currently in effect",
+		"Arkansas River at Derby",
+		"4.21 ft",
+		"id=\"flood-map\"",
+		"flood-disclaimer",
+		"K-15 / Hydraulic",
+		"Flooding",
+		"Use Broadway",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleFloodingDegradesGracefully(t *testing.T) {
+	testutils.InitTemplates(t)
+
+	errCache := &testutils.MockErrorCacheProvider{}
+	handler := HandleFlooding(errCache, errCache, errCache)
+	req := httptest.NewRequest("GET", "/flooding", nil)
+	w := httptest.NewRecorder()
+
+	if err := handler(w, req); err != nil {
+		t.Fatalf("handler returned error on upstream failure: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "temporarily unavailable") {
+		t.Error("expected degraded message in body")
+	}
+}

--- a/menu/menu.go
+++ b/menu/menu.go
@@ -58,6 +58,7 @@ func (p DefaultMenuProvider) New() *Menu {
 			{Label: "Current Temps", URL: "/temperatures", Tooltip: ""},
 			{Label: "Outlook", URL: "/outlook", Tooltip: ""},
 			{Label: "Rainfall Amounts", URL: "/rainfall", Tooltip: ""},
+			{Label: "Flooding", URL: "/flooding", Tooltip: "Real-time flood alerts, river gauges, and street closures", IsNew: true},
 			{Label: "Resources", URL: "/resources", Tooltip: ""},
 			{Label: "About", URL: "/about", Tooltip: ""},
 			{Label: "Disclaimer", URL: "/disclaimer", Tooltip: ""},

--- a/menu/menu.go
+++ b/menu/menu.go
@@ -55,6 +55,7 @@ func (p DefaultMenuProvider) New() *Menu {
 			{Label: "Radar", URL: "/", Tooltip: "What you really came here for"},
 			{Label: "Satellite", URL: "/satellite", Tooltip: ""},
 			{Label: "Watches/Warnings", URL: "/watches", Tooltip: ""},
+			{Label: "Alerts", URL: "/alerts", Tooltip: "Full text of active NWS alerts for Sedgwick County", IsNew: true},
 			{Label: "Current Temps", URL: "/temperatures", Tooltip: ""},
 			{Label: "Outlook", URL: "/outlook", Tooltip: ""},
 			{Label: "Rainfall Amounts", URL: "/rainfall", Tooltip: ""},

--- a/menu/menu_test.go
+++ b/menu/menu_test.go
@@ -15,6 +15,7 @@ func TestNew(t *testing.T) {
 		"Current Temps",
 		"Outlook",
 		"Rainfall Amounts",
+		"Flooding",
 		"Resources",
 		"About",
 		"Disclaimer",

--- a/menu/menu_test.go
+++ b/menu/menu_test.go
@@ -12,6 +12,7 @@ func TestNew(t *testing.T) {
 		"Radar",
 		"Satellite",
 		"Watches/Warnings",
+		"Alerts",
 		"Current Temps",
 		"Outlook",
 		"Rainfall Amounts",

--- a/static/css/wx.css
+++ b/static/css/wx.css
@@ -123,6 +123,88 @@ textarea,
   margin: 1em auto;
 }
 
+.textbox-watch {
+  width: 90%;
+  text-align: center;
+  background-color: #b06000;
+  color: #fff !important;
+  font-size: 0.8em;
+  border-top: 1px solid #ff9933;
+  border-bottom: 1px solid #ff9933;
+  padding: 0.5em 1em;
+  margin: 1em auto;
+}
+
+.textbox-ok {
+  width: 90%;
+  text-align: center;
+  background-color: #1f6b3a;
+  color: #fff !important;
+  font-size: 0.8em;
+  border-top: 1px solid #4cc878;
+  border-bottom: 1px solid #4cc878;
+  padding: 0.5em 1em;
+  margin: 1em auto;
+}
+
+/* Monospace block for forecast/alert text */
+.dot-matrix {
+  font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-size: 0.9em;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  color: #c8c8c8;
+  background-color: #1a1a1a;
+  border: 1px solid #333;
+  padding: 0.75em 1em;
+  margin: 0.5em 0 0;
+}
+
+/* Flooding page */
+
+#flood-map {
+  width: 100%;
+  height: 520px;
+  margin: 0.5em 0 1em;
+  border: 1px solid #444;
+}
+
+/* Dark-theme overrides for Pure's table classes. */
+.pure-table { width: 100%; color: #c8c8c8; background-color: #1c1c1c; border-color: #333; }
+.pure-table thead { background-color: #014884; color: #fff; }
+.pure-table td, .pure-table th { border-color: #333; font-size: 0.9em; }
+/* Override Pure's light-theme stripes so text stays readable on the dark site
+   and even rows don't blend into the body bg (#252525). */
+.pure-table-striped tr:nth-child(2n-1) td { background-color: #1c1c1c; }
+.pure-table-striped tr:nth-child(2n)   td { background-color: #2e2e2e; }
+
+.gauge-status {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 3px;
+  color: #fff;
+  font-size: 0.85em;
+}
+.gauge-status-None     { background-color: #1f6b3a; }
+.gauge-status-Action   { background-color: #b08d00; }
+.gauge-status-Minor    { background-color: #c47a00; }
+.gauge-status-Moderate { background-color: #9a2820; }
+.gauge-status-Major    { background-color: #5a0d56; }
+.gauge-status-Unknown  { background-color: #555;    }
+
+.flood-alert-body { padding: 0 0.5em 1em; color: #c8c8c8; font-size: 0.9em; }
+.flood-disclaimer {
+  font-size: 0.85em;
+  color: #888;
+  border: 1px dashed #444;
+  padding: 0.5em 0.75em;
+  margin: 1em auto;
+  width: 90%;
+}
+.flood-note      { padding: 0.5em 0; color: #888; font-size: 0.9em; font-style: italic; }
+.flood-generated { font-size: 0.8em; color: #777; text-align: right; margin: 0.5em 5%; }
+.closure-sub     { color: #888; font-size: 0.85em; }
+
 /* Image loading / failure states (applied by image-loading.js) */
 
 .img-wrapper {

--- a/static/css/wx.css
+++ b/static/css/wx.css
@@ -192,7 +192,7 @@ textarea,
 .gauge-status-Major    { background-color: #5a0d56; }
 .gauge-status-Unknown  { background-color: #555;    }
 
-.flood-alert-body { padding: 0 0.5em 1em; color: #c8c8c8; font-size: 0.9em; }
+.flood-alert-body { padding: 0 0.5em 1em; color: #c8c8c8; font-size: 0.9em; text-align: left; }
 .flood-disclaimer {
   font-size: 0.85em;
   color: #888;
@@ -200,8 +200,11 @@ textarea,
   padding: 0.5em 0.75em;
   margin: 1em auto;
   width: 90%;
+  text-align: left;
 }
-.flood-note      { padding: 0.5em 0; color: #888; font-size: 0.9em; font-style: italic; }
+.flood-note      { padding: 0.5em 0; color: #888; font-size: 0.9em; font-style: italic; text-align: left; }
+.pure-table td, .pure-table th { text-align: left; }
+.dot-matrix { text-align: left; }
 .flood-generated { font-size: 0.8em; color: #777; text-align: right; margin: 0.5em 5%; }
 .closure-sub     { color: #888; font-size: 0.85em; }
 

--- a/templates/alerts.page.html
+++ b/templates/alerts.page.html
@@ -1,0 +1,32 @@
+{{define "alerts"}} {{template "base" .}} {{end}} {{define "content"}}
+<div class="pure-g">
+  {{if not .Available}}
+    <div class="pure-u textbox-watch">Alert data temporarily unavailable.</div>
+  {{else if eq (len .Alerts) 0}}
+    <div class="pure-u textbox-ok">No active NWS alerts for Sedgwick County.</div>
+  {{else}}
+    <div class="pure-u textbox-warn">{{len .Alerts}} active alert{{if ne (len .Alerts) 1}}s{{end}} for Sedgwick County</div>
+  {{end}}
+</div>
+
+{{if and .Available (gt (len .Alerts) 0)}}
+  <div class="pure-g">
+    <div class="pure-u pure-u-1">
+      {{range .Alerts}}
+      <div class="pure-g">
+        <div class="pure-u {{if ge .SeverityRank 3}}textbox-warn{{else if eq .SeverityRank 2}}textbox-watch{{else}}textbox{{end}}">{{.Event}}</div>
+      </div>
+      <div class="flood-alert-body">
+        {{if .Headline}}{{.Headline}}<br />{{end}}
+        {{if .AreaDesc}}<em>{{.AreaDesc}}</em><br />{{end}}
+        {{if .Sent}}Issued {{.Sent}}{{if .Expires}} &middot; {{end}}{{end}}
+        {{if .Expires}}Expires {{.Expires}}{{end}}
+        {{if .Description}}<div class="dot-matrix">{{.Description}}</div>{{end}}
+      </div>
+      {{end}}
+    </div>
+  </div>
+{{end}}
+
+<div class="flood-generated">Last refreshed {{.GeneratedAt}}</div>
+{{end}}

--- a/templates/flooding.page.html
+++ b/templates/flooding.page.html
@@ -1,0 +1,235 @@
+{{define "flooding"}} {{template "base" .}} {{end}} {{define "content"}}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+  integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+
+{{/* Banner: textbox-warn for warning+flash, textbox-watch for watch+advisory, textbox-ok for clear. */}}
+<div class="pure-g">
+  <div class="pure-u {{if or (eq .BannerLevel "warning") (eq .BannerLevel "flash")}}textbox-warn{{else if or (eq .BannerLevel "watch") (eq .BannerLevel "advisory")}}textbox-watch{{else}}textbox-ok{{end}}">
+    {{.BannerText}}
+  </div>
+</div>
+
+<div class="pure-g">
+  {{/* Column 1: map + active alerts + active road closures */}}
+  <div class="pure-u pure-u-1 pure-u-md-1-2">
+    <div id="flood-map"></div>
+
+    <div class="pure-u textbox">Active flood alerts</div>
+    {{if not .AlertsAvailable}}
+      <div class="flood-note">Alert data temporarily unavailable.</div>
+    {{else if eq (len .Alerts) 0}}
+      <div class="flood-note">No flood alerts or warnings are currently in effect for Sedgwick County.</div>
+    {{else}}
+      {{range .Alerts}}
+      <div class="pure-g">
+        <div class="pure-u textbox-warn">{{.Event}}</div>
+      </div>
+      <div class="flood-alert-body">
+        {{if .Headline}}{{.Headline}}<br />{{end}}
+        {{if .AreaDesc}}<em>{{.AreaDesc}}</em><br />{{end}}
+        {{if .Expires}}Expires {{.Expires}}{{end}}
+        {{if .Description}}<div class="dot-matrix">{{.Description}}</div>{{end}}
+      </div>
+      {{end}}
+    {{end}}
+
+    <div class="pure-u textbox">Active road closures (flood &amp; storm damage)</div>
+    {{if not .ClosuresAvailable}}
+      <div class="flood-note">Sedgwick County closure data temporarily unavailable.</div>
+    {{else if eq (len .Closures) 0}}
+      <div class="flood-note">No active flood or storm-damage road closures reported in Sedgwick County.</div>
+    {{else}}
+      <table class="pure-table pure-table-horizontal pure-table-striped">
+        <thead>
+          <tr>
+            <th>Street</th>
+            <th>Between</th>
+            <th>City</th>
+            <th>Reason</th>
+            <th>Started</th>
+            <th>Alt route</th>
+          </tr>
+        </thead>
+        <tbody>
+        {{range .Closures}}
+          <tr>
+            <td>{{.Street}}{{if .Description}}<br /><span class="closure-sub">{{.Description}}</span>{{end}}</td>
+            <td>{{if or .Begin .End}}{{.Begin}} &mdash; {{.End}}{{end}}</td>
+            <td>{{.City}}</td>
+            <td>{{.Reason}}</td>
+            <td>{{.StartedAt}}</td>
+            <td>{{.AltRoute}}</td>
+          </tr>
+        {{end}}
+        </tbody>
+      </table>
+    {{end}}
+  </div>
+
+  {{/* Column 2: river and creek gauges */}}
+  <div class="pure-u pure-u-1 pure-u-md-1-2">
+    <div class="pure-u textbox">River and creek gauges</div>
+    {{if not .GaugesAvailable}}
+      <div class="flood-note">Gauge data temporarily unavailable.</div>
+    {{else}}
+      <table class="pure-table pure-table-horizontal pure-table-striped">
+        <thead>
+          <tr>
+            <th>Gauge</th>
+            <th>Current</th>
+            <th>Flood</th>
+            <th>Status</th>
+            <th>Observed</th>
+          </tr>
+        </thead>
+        <tbody>
+        {{range .Gauges}}
+          <tr>
+            <td>{{.Name}}</td>
+            <td>{{.Stage}}</td>
+            <td>{{.FloodStage}}</td>
+            <td><span class="gauge-status gauge-status-{{.Status}}">{{.Status}}</span></td>
+            <td>{{.Observed}}</td>
+          </tr>
+        {{end}}
+        </tbody>
+      </table>
+    {{end}}
+  </div>
+</div>
+
+<div class="flood-disclaimer">
+  <strong>What this page shows.</strong>
+  River and creek levels are measured live by NWS/USGS gauges (15&ndash;60 minute updates). Active flood
+  warnings and watches come straight from the National Weather Service and may include storm-based
+  polygons that cover only a few neighborhoods. The optional <em>FEMA flood zones</em> overlay shows
+  the city's mapped 100-year (high risk) and 500-year (moderate risk) floodplains &mdash; static
+  data, not real time, but useful for seeing <em>where</em> warnings are most likely to translate
+  into actual flooding.
+  <br /><br />
+  <strong>Active road closures</strong> come from Sedgwick County Public Works' public road-closure
+  feed, filtered to in-progress flood and storm-damage closures. The feed covers all of Sedgwick
+  County including the city of Wichita, but only shows streets after county or city crews have
+  reported a barricade &mdash; actual flooding can occur before a closure is posted.
+  <br /><br />
+  <strong>What it doesn't show.</strong>
+  There is no public real-time per-intersection flood-sensor feed. The City of Wichita's separate
+  road-closure layer publishes only construction and event closures, not high-water barricades, so
+  it's not used here. Always defer to <a href="https://www.weather.gov/ict/">NWS Wichita</a> and
+  local emergency officials, and never drive through flooded roadways.
+</div>
+
+<div class="flood-generated">Last refreshed {{.GeneratedAt}}</div>
+
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+  integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+<script src="https://unpkg.com/esri-leaflet@3.0.12/dist/esri-leaflet.js"
+  integrity="sha512-O3PvLPDvuHmpFqK56QlSnFvAcKxAyB9OqA0Qe+lQs6Y4QXQEZuSDuYn14d2KqGsB3zSP9aE0riZcWStpwfvuvA=="
+  crossorigin=""></script>
+<script>
+(function () {
+  var map = L.map('flood-map').setView([37.69, -97.34], 10);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 18,
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+
+  function alertStyle(feature) {
+    var event = ((feature.properties || {}).event || '').toLowerCase();
+    var color = '#b08d00';
+    if (event.indexOf('flash flood warning') !== -1) color = '#5a0d56';
+    else if (event.indexOf('flood warning') !== -1) color = '#9a2820';
+    else if (event.indexOf('watch') !== -1) color = '#c47a00';
+    return { color: color, weight: 2, fillOpacity: 0.25, fillColor: color };
+  }
+
+  var alertsLayer = L.layerGroup();
+  var alerts = {{.AlertsGeoJSON}};
+  if (alerts && alerts.features && alerts.features.length) {
+    L.geoJSON(alerts, {
+      style: alertStyle,
+      onEachFeature: function (f, layer) {
+        var p = f.properties || {};
+        var html = '<strong>' + (p.event || 'Alert') + '</strong>';
+        if (p.headline) html += '<br/>' + p.headline;
+        if (p.areaDesc) html += '<br/><em>' + p.areaDesc + '</em>';
+        layer.bindPopup(html);
+      }
+    }).addTo(alertsLayer);
+  }
+  alertsLayer.addTo(map);
+
+  var statusColors = {
+    'None': '#1f6b3a', 'Action': '#b08d00', 'Minor': '#c47a00',
+    'Moderate': '#9a2820', 'Major': '#5a0d56', 'Unknown': '#555'
+  };
+  var gaugesLayer = L.layerGroup();
+  var gauges = {{.GaugesGeoJSON}};
+  if (gauges && gauges.features) {
+    L.geoJSON(gauges, {
+      pointToLayer: function (f, latlng) {
+        var p = f.properties || {};
+        return L.circleMarker(latlng, {
+          radius: 7,
+          color: '#000', weight: 1,
+          fillColor: statusColors[p.status] || '#555',
+          fillOpacity: 0.9
+        });
+      },
+      onEachFeature: function (f, layer) {
+        var p = f.properties || {};
+        var html = '<strong>' + (p.name || p.id) + '</strong><br/>';
+        html += 'Stage: ' + (p.stage || 'n/a') + '<br/>';
+        html += 'Flood stage: ' + (p.floodStage || 'n/a') + '<br/>';
+        html += 'Status: ' + (p.status || 'Unknown');
+        if (p.observed) html += '<br/><em>' + p.observed + '</em>';
+        layer.bindPopup(html);
+      }
+    }).addTo(gaugesLayer);
+  }
+  gaugesLayer.addTo(map);
+
+  // Sedgwick County active flood / storm-damage road closures.
+  var closuresLayer = L.layerGroup();
+  var closures = {{.ClosuresGeoJSON}};
+  if (closures && closures.features && closures.features.length) {
+    var redIcon = L.divIcon({
+      className: 'flood-closure-marker',
+      html: '<div style="width:14px;height:14px;border-radius:50%;background:#d62728;border:2px solid #fff;box-shadow:0 0 2px #000"></div>',
+      iconSize: [18, 18], iconAnchor: [9, 9]
+    });
+    L.geoJSON(closures, {
+      pointToLayer: function (f, latlng) { return L.marker(latlng, { icon: redIcon }); },
+      onEachFeature: function (f, layer) {
+        var p = f.properties || {};
+        var html = '<strong>' + (p.street || 'Closure') + '</strong>';
+        if (p.begin || p.end) html += '<br/>' + (p.begin || '') + ' &mdash; ' + (p.end || '');
+        if (p.city)        html += '<br/>' + p.city;
+        if (p.reason)      html += '<br/><strong>' + p.reason + '</strong>';
+        if (p.description) html += '<br/>' + p.description;
+        if (p.altRoute)    html += '<br/><em>Alt route: ' + p.altRoute + '</em>';
+        if (p.startedAt)   html += '<br/><em>Started ' + p.startedAt + '</em>';
+        layer.bindPopup(html);
+      }
+    }).addTo(closuresLayer);
+  }
+  closuresLayer.addTo(map);
+
+  // FEMA flood zones (City of Wichita public MapServer, layer 4 = Flood Zones).
+  // Off by default; toggle in the layer control.
+  var floodZonesLayer = L.esri.dynamicMapLayer({
+    url: 'https://gismaps.wichita.gov/ageweb/rest/services/MISC/Flood_Zones/MapServer',
+    layers: [4],
+    opacity: 0.45,
+    f: 'image'
+  });
+
+  L.control.layers(null, {
+    'Flood warnings/watches': alertsLayer,
+    'River gauges': gaugesLayer,
+    'Active road closures': closuresLayer,
+    'FEMA flood zones (Wichita)': floodZonesLayer
+  }, { collapsed: false }).addTo(map);
+})();
+</script>
+{{end}}

--- a/templates/resources.page.html
+++ b/templates/resources.page.html
@@ -8,6 +8,39 @@
   <h2 class="content-subhead">Streaming Video from Storm Chasers</h2>
   <ul>
     <li>
+      <a href="https://www.youtube.com/@RyanHallYall" target="_blank">Ryan Hall</a> More an online weather-caster than a
+      storm chaser, but he includes some storm-chasers on his stream. Also runs a nonprofit that helps fill in gaps for
+      storm victims that aren't served by Salvation Army and FEMA.
+    </li>
+    <li>
+      <a href="https://www.youtube.com/@BrandonCopicWx" target="_blank">Brandon Copic</a>
+    </li>
+    <li>
+      <a href="https://www.youtube.com/@FreddyMcKinney" target="_blank">Freddy McKinney</a>
+    </li>
+    <li>
+      <a href="https://www.youtube.com/@StormChaserBradArnold" target="_blank">Brad Arnold</a>
+    </li>
+    <li>
+      <a href="https://www.youtube.com/@coreygerkenwx" target="_blank">Corey Gerkin</a>
+    </li>
+    <li>
+      <a href="https://www.youtube.com/@DanielShawAU" target="_blank">Daniel Shaw</a>
+    </li>
+    <li>
+      <a href="https://www.youtube.com/@tornadopaigeyy" target="_blank">Tornado Paigeyy</a>
+    </li>
+    <li>
+      <a href="https://www.youtube.com/@ConnorCroff" target="_blank">Connor Croff</a>
+    </li>
+    <li>
+      <a href="https://www.youtube.com/@StormChaserVince" target="_blank">Vince Waelti</a>
+    </li>
+    <li>
+      <a href="https://www.youtube.com/@stormrunnermedia" target="_blank">Stormrunner Media</a>
+    </li>
+    <li><a href="https://www.youtube.com/@ReedTimmerWx" target="_blank">Reed Timmer</a> fun in small doses</li>
+    <li>
       <a href="https://www.severestudios.com/livechase" target="_blank">Severestudios.com</a> "The Leader in Live Severe
       Weather Streaming"
     </li>

--- a/templates/temperatures.page.html
+++ b/templates/temperatures.page.html
@@ -1,8 +1,5 @@
 {{define "temperatures"}} {{template "base" .}} {{end}} {{define "content"}}
 <div class="pure-g">
-  <div class="pure-u textbox-warn">
-    Apologies; we are having some trouble with some of our upstream temperature maps.
-  </div>
   <div class="pure-u pure-u-md-1 pure-u-lg-1-2 pure-u-xl-1-3">
     <!-- ****** KSNW ***** -->
     <a href="https://www.ksn.com/weather/images/kansas-temps/">


### PR DESCRIPTION
## Summary
- Add `/alerts` page with full text of active NWS alerts
- Add real-time `/flooding` page for Sedgwick County
- Add storm chaser YouTube links to resources page
- Fix flooding page left-alignment overridden by global `.pure-u` center rule
- Remove stale upstream-issue banner from temperatures page
- Enable frontend-design Claude Code plugin

## Test plan
- [ ] `/alerts` renders active NWS alerts
- [ ] `/flooding` displays Sedgwick County real-time data and is left-aligned
- [ ] Resources page shows storm chaser YouTube links
- [ ] Temperatures page no longer shows the upstream-issue banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)